### PR TITLE
fix typo to bump build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # [react.cologne](https://react.cologne)
 
-Website of [react.cologne](https://react.cologne), built with [Gatbsy](https://www.gatsbyjs.org).
+Website of [react.cologne](https://react.cologne), built with [Gatsby](https://www.gatsbyjs.org).


### PR DESCRIPTION
https://react.cologne/ still shows past meetup as upcoming meetup